### PR TITLE
:bug: Fix move ctor for `hal::static_list` & `hal::can_router`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
     - cron: '0 12 * * 0'
 
 jobs:
-  lint:
+  ci:
     uses: libhal/libhal/.github/workflows/checks.yml@main
     with:
       library: libhal-util

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,9 +9,9 @@ import os
 required_conan_version = ">=1.50.0"
 
 
-class LibHALConan(ConanFile):
+class LibhalUtilConan(ConanFile):
     name = "libhal-util"
-    version = "0.3.7"
+    version = "0.3.8"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/include/libhal-util/static_list.hpp
+++ b/include/libhal-util/static_list.hpp
@@ -287,8 +287,29 @@ public:
 
   constexpr static_list& operator=(static_list& p_other) = delete;
   constexpr static_list(static_list& p_other) = delete;
-  constexpr static_list& operator=(static_list&& p_other) = default;
-  constexpr static_list(static_list&& p_other) = default;
+  constexpr static_list& operator=(static_list&& p_other)
+  {
+    m_head = p_other.m_head;
+    m_tail = p_other.m_tail;
+    m_size = p_other.m_size;
+
+    // Set all fields to NULL to indicate to the destructor that this list
+    // should not go through the destructor sequence.
+    p_other.m_head = nullptr;
+    p_other.m_tail = nullptr;
+    p_other.m_size = 0;
+
+    for (auto element = begin(); element != end(); element++) {
+      element.m_self->m_list = this;
+    }
+
+    return *this;
+  }
+
+  constexpr static_list(static_list&& p_other)
+  {
+    *this = std::move(p_other);
+  }
 
   /**
    * @brief Add default constructed item to the end of the list
@@ -376,8 +397,8 @@ public:
       return;
     }
 
-    for (auto start = begin(); start != end(); start++) {
-      start.m_self->m_list = nullptr;
+    for (auto element = begin(); element != end(); element++) {
+      element.m_self->m_list = nullptr;
     }
   }
 

--- a/tests/static_list.test.cpp
+++ b/tests/static_list.test.cpp
@@ -349,5 +349,33 @@ void static_list_test()
     expect(that % nullptr == array_of_items[3].list());
     expect(that % nullptr == array_of_items[4].list());
   };
+
+  "static_list::static_list(&&) moved object doesn't destruct"_test = []() {
+    // Setup
+    static_list<int> new_list;
+    static_list<int> original_list;
+
+    auto array_of_items_0 = original_list.push_back();
+    auto array_of_items_1 = original_list.push_back();
+    auto array_of_items_2 = original_list.push_back();
+    auto array_of_items_3 = original_list.push_back();
+    auto array_of_items_4 = original_list.push_back();
+
+    expect(that % &original_list == array_of_items_0.list());
+    expect(that % &original_list == array_of_items_1.list());
+    expect(that % &original_list == array_of_items_2.list());
+    expect(that % &original_list == array_of_items_3.list());
+    expect(that % &original_list == array_of_items_4.list());
+
+    // Exercise
+    new_list = std::move(original_list);
+
+    // Verify
+    expect(that % &new_list == array_of_items_0.list());
+    expect(that % &new_list == array_of_items_1.list());
+    expect(that % &new_list == array_of_items_2.list());
+    expect(that % &new_list == array_of_items_3.list());
+    expect(that % &new_list == array_of_items_4.list());
+  };
 };
 }  // namespace hal


### PR DESCRIPTION
Remove usage of hal::move_interceptor for `hal::can_router`. The major issue with hal::move_interceptor is that it results in an exact clone between both objects. There is no way for either object to know its a "moved-from" object and thus when they destruct or are destroyed, they end up disabling both objects as they have common resources.

Move constructor for `hal::can_router` now reassigns the can receive handler to the new object and sets the pointer to the can peripheral on the moved-from object is set to `nullptr` to differentiate between objects.

Move constructor for `hal::static_list` makes the moved-from empty and also moves all of the list item from the moved-from list to the new list.