### PR TITLE
:bug: Fix i2c util timeout inference

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibhalUtilConan(ConanFile):
     name = "libhal-util"
-    version = "0.3.9"
+    version = "0.3.10"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,3 +75,11 @@ target_link_options(${PROJECT_NAME} PRIVATE
 target_link_libraries(${PROJECT_NAME} PRIVATE
   Boost::ut
   libhal::util)
+
+add_custom_command(TARGET ${PROJECT_NAME}
+  POST_BUILD
+  COMMAND ${CMAKE_COMMAND}
+  -P ${CMAKE_SOURCE_DIR}/remove_gcda.cmake
+  COMMENT "Deleting Previous Coverage Files..."
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)

--- a/tests/i2c.test.cpp
+++ b/tests/i2c.test.cpp
@@ -324,5 +324,29 @@ void i2c_util_test()
     expect(that % 0 == i2c.m_out.size());
     expect(that % nullptr == i2c.m_out.data());
   };
+
+  "Use all APIs without timeout parameter"_test = []() {
+    // Setup
+    test_i2c i2c;
+
+    const std::array<hal::byte, 4> write_data{};
+    std::array<hal::byte, 4> read_data{};
+
+    // Exercise
+    auto result_write = write(i2c, successful_address, write_data);
+    auto result_read = read(i2c, successful_address, read_data);
+    auto result_wr =
+      write_then_read(i2c, successful_address, write_data, read_data);
+    auto result_read_buffer = read<2>(i2c, successful_address);
+    auto result_wr_buffer =
+      write_then_read<2>(i2c, successful_address, write_data);
+
+    // Verify
+    expect(bool{ result_read });
+    expect(bool{ result_write });
+    expect(bool{ result_wr });
+    expect(bool{ result_read_buffer });
+    expect(bool{ result_wr_buffer });
+  };
 };
 }  // namespace hal

--- a/tests/remove_gcda.cmake
+++ b/tests/remove_gcda.cmake
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.15)
+
+function(remove_gcda)
+  file(GLOB_RECURSE GCDA_FILES ${CMAKE_BINARY_DIR}/**/*.gcda)
+
+  if(GCDA_FILES)
+    file(REMOVE ${GCDA_FILES})
+  endif()
+endfunction()
+
+remove_gcda()


### PR DESCRIPTION
- ⬆️ Bump version to 0.3.10
- Add build step to remove coverage files after each build to remove the
  error:

  ```
  profiling: test.cpp.gcda: cannot merge previous GCDA file: mismatched
  number of counters (12)
  ```

Resolves https://github.com/libhal/libhal-util/issues/47