### PR TITLE
:rocket: Launch version 1.0.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibhalUtilConan(ConanFile):
     name = "libhal-util"
-    version = "0.3.11"
+    version = "1.0.0"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"
@@ -59,7 +59,7 @@ class LibhalUtilConan(ConanFile):
         basic_layout(self)
 
     def requirements(self):
-        self.requires("libhal/0.3.5")
+        self.requires("libhal/[^1.0.0]")
 
     def package(self):
         copy(self, "LICENSE", dst=os.path.join(

--- a/include/libhal-util/i2c.hpp
+++ b/include/libhal-util/i2c.hpp
@@ -25,12 +25,13 @@ namespace hal {
  * @param p_address - target address
  * @param p_data_out - buffer of bytes to write to the target device
  * @param p_timeout - amount of time to execute the transaction
- * @return status - success or failure
+ * @return hal::result<hal::i2c::transaction_t> - success or failure
  */
-[[nodiscard]] inline status write(i2c& p_i2c,
-                                  hal::byte p_address,
-                                  std::span<const hal::byte> p_data_out,
-                                  timeout auto p_timeout)
+[[nodiscard]] inline hal::result<hal::i2c::transaction_t> write(
+  i2c& p_i2c,
+  hal::byte p_address,
+  std::span<const hal::byte> p_data_out,
+  timeout auto p_timeout)
 {
   return p_i2c.transaction(
     p_address, p_data_out, std::span<hal::byte>{}, p_timeout);
@@ -45,11 +46,10 @@ namespace hal {
  * @param p_i2c - i2c driver
  * @param p_address - target address
  * @param p_data_out - buffer of bytes to write to the target device
- * @return status - success or failure
+ * @return hal::result<hal::i2c::transaction_t> - success or failure
  */
-[[nodiscard]] inline status write(i2c& p_i2c,
-                                  hal::byte p_address,
-                                  std::span<const hal::byte> p_data_out)
+[[nodiscard]] inline hal::result<hal::i2c::transaction_t>
+write(i2c& p_i2c, hal::byte p_address, std::span<const hal::byte> p_data_out)
 {
   return write(p_i2c, p_address, p_data_out, hal::never_timeout());
 }
@@ -63,12 +63,13 @@ namespace hal {
  * @param p_address - target address
  * @param p_data_in - buffer to read bytes into from target device
  * @param p_timeout - amount of time to execute the transaction
- * @return status - success or failure
+ * @return hal::result<hal::i2c::transaction_t> - success or failure
  */
-[[nodiscard]] inline status read(i2c& p_i2c,
-                                 hal::byte p_address,
-                                 std::span<hal::byte> p_data_in,
-                                 timeout auto p_timeout)
+[[nodiscard]] inline hal::result<hal::i2c::transaction_t> read(
+  i2c& p_i2c,
+  hal::byte p_address,
+  std::span<hal::byte> p_data_in,
+  timeout auto p_timeout)
 {
   return p_i2c.transaction(
     p_address, std::span<hal::byte>{}, p_data_in, p_timeout);
@@ -83,11 +84,10 @@ namespace hal {
  * @param p_i2c - i2c driver
  * @param p_address - target address
  * @param p_data_in - buffer to read bytes into from target device
- * @return status - success or failure
+ * @return hal::result<hal::i2c::transaction_t> - success or failure
  */
-[[nodiscard]] inline status read(i2c& p_i2c,
-                                 hal::byte p_address,
-                                 std::span<hal::byte> p_data_in)
+[[nodiscard]] inline hal::result<hal::i2c::transaction_t>
+read(i2c& p_i2c, hal::byte p_address, std::span<hal::byte> p_data_in)
 {
   return read(p_i2c, p_address, p_data_in, hal::never_timeout());
 }
@@ -146,9 +146,9 @@ template<size_t BytesToRead>
  * @param p_data_in - buffer to read bytes into from target device
  * @param p_timeout - amount of time to execute the transaction
  *
- * @return status - success or failure
+ * @return hal::result<hal::i2c::transaction_t> - success or failure
  */
-[[nodiscard]] inline status write_then_read(
+[[nodiscard]] inline hal::result<hal::i2c::transaction_t> write_then_read(
   i2c& p_i2c,
   hal::byte p_address,
   std::span<const hal::byte> p_data_out,
@@ -172,9 +172,9 @@ template<size_t BytesToRead>
  * @param p_data_out - buffer of bytes to write to the target device
  * @param p_data_in - buffer to read bytes into from target device
  *
- * @return status - success or failure
+ * @return hal::result<hal::i2c::transaction_t> - success or failure
  */
-[[nodiscard]] inline status write_then_read(
+[[nodiscard]] inline hal::result<hal::i2c::transaction_t> write_then_read(
   i2c& p_i2c,
   hal::byte p_address,
   std::span<const hal::byte> p_data_out,
@@ -236,9 +236,11 @@ template<size_t BytesToRead>
  *
  * @param p_i2c - i2c driver
  * @param p_address - target address to probe for
- * @return status - success or failure
+ * @return hal::result<hal::i2c::transaction_t> - success or failure
  */
-[[nodiscard]] inline status probe(i2c& p_i2c, hal::byte p_address)
+[[nodiscard]] inline hal::result<hal::i2c::transaction_t> probe(
+  i2c& p_i2c,
+  hal::byte p_address)
 {
   // p_data_in: empty placeholder for transcation's data_in
   std::array<hal::byte, 1> data_in;

--- a/include/libhal-util/spi.hpp
+++ b/include/libhal-util/spi.hpp
@@ -21,10 +21,11 @@ namespace hal {
  *
  * @param p_spi - spi driver
  * @param p_data_out - data to be written to the SPI bus
- * @return status - success or failure
+ * @return result<hal::spi::transfer_t> - success or failure
  */
-[[nodiscard]] inline status write(spi& p_spi,
-                                  std::span<const hal::byte> p_data_out)
+[[nodiscard]] inline result<hal::spi::transfer_t> write(
+  spi& p_spi,
+  std::span<const hal::byte> p_data_out)
 {
   return p_spi.transfer(
     p_data_out, std::span<hal::byte>{}, spi::default_filler);
@@ -39,11 +40,12 @@ namespace hal {
  * @param p_data_in - buffer to receive bytes back from the SPI bus
  * @param p_filler - filler data placed on the bus in place of actual write
  * data.
- * @return status - success or failure
+ * @return result<hal::spi::transfer_t> - success or failure
  */
-[[nodiscard]] inline status read(spi& p_spi,
-                                 std::span<hal::byte> p_data_in,
-                                 hal::byte p_filler = spi::default_filler)
+[[nodiscard]] inline result<hal::spi::transfer_t> read(
+  spi& p_spi,
+  std::span<hal::byte> p_data_in,
+  hal::byte p_filler = spi::default_filler)
 {
   return p_spi.transfer(std::span<hal::byte>{}, p_data_in, p_filler);
 }
@@ -86,9 +88,9 @@ template<size_t BytesToRead>
  * @param p_data_in - buffer to receive bytes back from the SPI bus
  * @param p_filler - filler data placed on the bus when the read operation
  * begins.
- * @return status - success or failure
+ * @return result<hal::spi::transfer_t> - success or failure
  */
-[[nodiscard]] inline status write_then_read(
+[[nodiscard]] inline result<hal::spi::transfer_t> write_then_read(
   spi& p_spi,
   std::span<const hal::byte> p_data_out,
   std::span<hal::byte> p_data_in,

--- a/include/libhal-util/steady_clock.hpp
+++ b/include/libhal-util/steady_clock.hpp
@@ -30,7 +30,8 @@ public:
                                              hal::time_duration p_duration)
   {
     using period = decltype(p_duration)::period;
-    const auto frequency = p_steady_clock.frequency();
+    const auto frequency =
+      HAL_CHECK(p_steady_clock.frequency()).operating_frequency;
     const auto tick_period = wavelength<period>(frequency);
     auto ticks_required = p_duration / tick_period;
     using unsigned_ticks = std::make_unsigned_t<decltype(ticks_required)>;
@@ -40,7 +41,8 @@ public:
     }
 
     const auto ticks = static_cast<unsigned_ticks>(ticks_required);
-    const auto future_timestamp = ticks + HAL_CHECK(p_steady_clock.uptime());
+    const auto future_timestamp =
+      ticks + HAL_CHECK(p_steady_clock.uptime()).ticks;
 
     return steady_clock_timeout(p_steady_clock, future_timestamp);
   }
@@ -81,7 +83,7 @@ public:
    */
   status operator()()
   {
-    auto current_count = HAL_CHECK(m_counter->uptime());
+    auto current_count = HAL_CHECK(m_counter->uptime()).ticks;
 
     if (current_count >= m_cycles_until_timeout) {
       return hal::new_error(std::errc::timed_out);

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -11,14 +11,14 @@ private:
     return hal::success();
   }
 
-  hal::status driver_transaction(
+  hal::result<hal::i2c::transaction_t> driver_transaction(
     [[maybe_unused]] hal::byte p_address,
     [[maybe_unused]] std::span<const hal::byte> p_data_out,
     std::span<hal::byte> p_data_in,
     [[maybe_unused]] hal::function_ref<hal::timeout_function> p_timeout)
   {
     std::iota(p_data_in.begin(), p_data_in.end(), 5);
-    return hal::success();
+    return hal::i2c::transaction_t{};
   }
 };
 

--- a/tests/can.test.cpp
+++ b/tests/can.test.cpp
@@ -28,13 +28,18 @@ private:
     return success();
   };
 
-  status driver_send(const message_t& p_message) override
+  status driver_bus_on() override
+  {
+    return success();
+  }
+
+  result<send_t> driver_send(const message_t& p_message) override
   {
     m_message = p_message;
     if (m_return_error_status) {
       return hal::new_error();
     }
-    return success();
+    return send_t{};
   };
 
   void driver_on_receive(hal::callback<handler> p_handler) override

--- a/tests/conanfile.txt
+++ b/tests/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 boost-ext-ut/1.1.9
-libhal-util/0.3.9
+libhal-util/1.0.0
 
 [generators]
 CMakeToolchain

--- a/tests/i2c.test.cpp
+++ b/tests/i2c.test.cpp
@@ -30,7 +30,7 @@ void i2c_util_test()
     {
       return {};
     }
-    [[nodiscard]] status driver_transaction(
+    [[nodiscard]] result<transaction_t> driver_transaction(
       hal::byte p_address,
       std::span<const hal::byte> p_out,
       std::span<hal::byte> p_in,
@@ -48,7 +48,7 @@ void i2c_util_test()
 
       (void)p_timeout();
 
-      return {};
+      return transaction_t{};
     }
 
     virtual ~test_i2c()

--- a/tests/serial.test.cpp
+++ b/tests/serial.test.cpp
@@ -64,10 +64,10 @@ void serial_util_test()
       };
     }
 
-    status driver_flush() override
+    result<flush_t> driver_flush() override
     {
       flush_called = true;
-      return {};
+      return flush_t{};
     }
 
     virtual ~fake_serial()
@@ -371,9 +371,9 @@ void serial_util_test()
       return hal::new_error();
     }
 
-    status driver_flush() override
+    result<flush_t> driver_flush() override
     {
-      return hal::success();
+      return flush_t{};
     }
 
     virtual ~save_serial_write()

--- a/tests/spi.test.cpp
+++ b/tests/spi.test.cpp
@@ -18,9 +18,10 @@ void spi_util_test()
     {
       return {};
     }
-    [[nodiscard]] status driver_transfer(std::span<const hal::byte> p_out,
-                                         std::span<hal::byte> p_in,
-                                         hal::byte p_filler) override
+    [[nodiscard]] result<transfer_t> driver_transfer(
+      std::span<const hal::byte> p_out,
+      std::span<hal::byte> p_in,
+      hal::byte p_filler) override
     {
       if (!p_out.empty()) {
         m_out = p_out;

--- a/tests/steady_clock.test.cpp
+++ b/tests/steady_clock.test.cpp
@@ -21,17 +21,17 @@ void steady_clock_utility_test()
     bool will_fail = false;
 
   private:
-    hertz driver_frequency() override
+    result<frequency_t> driver_frequency() override
     {
-      return expected_frequency;
+      return frequency_t{ .operating_frequency = expected_frequency };
     }
 
-    result<std::uint64_t> driver_uptime() override
+    result<uptime_t> driver_uptime() override
     {
       if (will_fail) {
         return new_error();
       }
-      return uptime++;
+      return uptime_t{ .ticks = uptime++ };
     }
   };
 
@@ -56,7 +56,8 @@ void steady_clock_utility_test()
     // Verify: subtract 2 because 2 invocations are required in order to get
     //         the start uptime and another to check what the latest uptime is.
     expect(that % expected.count() == (test_steady_clock.uptime - 2));
-    expect(that % expected_frequency == test_steady_clock.frequency());
+    expect(that % expected_frequency ==
+           test_steady_clock.frequency().value().operating_frequency);
   };
 
   "hal::create_timeout(hal::steady_clock, 50ns)"_test = []() {
@@ -85,7 +86,8 @@ void steady_clock_utility_test()
     expect(that % success) << "std::errc::timed_out handler was not called!";
     // After the last call to uptime() the uptime value is incremented by one
     expect(that % expected.count() == test_steady_clock.uptime - 1);
-    expect(that % expected_frequency == test_steady_clock.frequency());
+    expect(that % expected_frequency ==
+           test_steady_clock.frequency().value().operating_frequency);
   };
 
   "hal::create_timeout(hal::steady_clock, 1337ns)"_test = []() {
@@ -113,7 +115,8 @@ void steady_clock_utility_test()
     // Verify
     expect(that % success) << "std::errc::timed_out handler was not called!";
     expect(that % expected.count() == test_steady_clock.uptime - 1);
-    expect(that % expected_frequency == test_steady_clock.frequency());
+    expect(that % expected_frequency ==
+           test_steady_clock.frequency().value().operating_frequency);
   };
 
   "hal::create_timeout(hal::steady_clock, -5ns) returns error"_test = []() {
@@ -127,7 +130,8 @@ void steady_clock_utility_test()
     // Verify
     expect(bool{ result });
     expect(that % 1 == test_steady_clock.uptime);
-    expect(that % expected_frequency == test_steady_clock.frequency());
+    expect(that % expected_frequency ==
+           test_steady_clock.frequency().value().operating_frequency);
   };
 
   "hal::create_timeout(hal::steady_clock, 100ns) but fails"_test = []() {
@@ -142,7 +146,8 @@ void steady_clock_utility_test()
     // Verify
     expect(!bool{ result });
     expect(that % 0 == test_steady_clock.uptime);
-    expect(that % expected_frequency == test_steady_clock.frequency());
+    expect(that % expected_frequency ==
+           test_steady_clock.frequency().value().operating_frequency);
   };
 
   // =============== delay ===============
@@ -160,7 +165,8 @@ void steady_clock_utility_test()
     // Verify: subtract 2 because 2 invocations are required in order to get
     //         the start uptime and another to check what the latest uptime is.
     expect(that % expected.count() == (test_steady_clock.uptime - 2));
-    expect(that % expected_frequency == test_steady_clock.frequency());
+    expect(that % expected_frequency ==
+           test_steady_clock.frequency().value().operating_frequency);
   };
 
   "hal::delay(hal::steady_clock, 50ns)"_test = []() {
@@ -174,7 +180,8 @@ void steady_clock_utility_test()
     // Verify
     expect(bool{ result });
     expect(that % expected.count() == test_steady_clock.uptime - 1);
-    expect(that % expected_frequency == test_steady_clock.frequency());
+    expect(that % expected_frequency ==
+           test_steady_clock.frequency().value().operating_frequency);
   };
 
   "hal::delay(hal::steady_clock, 1337ns)"_test = []() {
@@ -188,7 +195,8 @@ void steady_clock_utility_test()
     // Verify
     expect(bool{ result });
     expect(that % expected.count() == test_steady_clock.uptime - 1);
-    expect(that % expected_frequency == test_steady_clock.frequency());
+    expect(that % expected_frequency ==
+           test_steady_clock.frequency().value().operating_frequency);
   };
 
   "hal::delay(hal::steady_clock, -5ns) returns error"_test = []() {
@@ -203,7 +211,8 @@ void steady_clock_utility_test()
     expect(bool{ result });
     // Verify: Adjust uptime by 2 because at least 2 calls to uptime()
     expect(that % 0 == test_steady_clock.uptime - 2);
-    expect(that % expected_frequency == test_steady_clock.frequency());
+    expect(that % expected_frequency ==
+           test_steady_clock.frequency().value().operating_frequency);
   };
 
   "hal::delay(hal::steady_clock, 100ns) but fails"_test = []() {
@@ -219,7 +228,8 @@ void steady_clock_utility_test()
     expect(!bool{ result });
     // Verify: Adjust uptime by 2 because at least 2 calls to uptime()
     expect(that % 0 == test_steady_clock.uptime);
-    expect(that % expected_frequency == test_steady_clock.frequency());
+    expect(that % expected_frequency ==
+           test_steady_clock.frequency().value().operating_frequency);
   };
 
   "hal::timeout_generator(hal::steady_clock)"_test = []() {
@@ -249,7 +259,8 @@ void steady_clock_utility_test()
     expect(that % success) << "std::errc::timed_out handler was not called!";
     // After the last call to uptime() the uptime value is incremented by one
     expect(that % expected.count() == test_steady_clock.uptime - 1);
-    expect(that % expected_frequency == test_steady_clock.frequency());
+    expect(that % expected_frequency ==
+           test_steady_clock.frequency().value().operating_frequency);
   };
 };
 }  // namespace hal


### PR DESCRIPTION
- :arrow_up: Upgrade to libhal/[^1.0.0]. Using `^` to ensure that libhal-util can work any other library with a compatible major number of libhal.
- :recycle: Refactor code to use latest libhal code