### PR TITLE
:sparkles: Add additional work_state functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 12 * * 0'
+    - cron: "0 12 * * 0"
 
 jobs:
   ci:
-    uses: libhal/ci/.github/workflows/library.yml@main
+    uses: libhal/ci/.github/workflows/library.yml@1.0.1
     with:
       library: libhal-util
       coverage: true

--- a/conanfile.py
+++ b/conanfile.py
@@ -27,7 +27,7 @@ required_conan_version = ">=1.50.0"
 
 class libhal_util_conan(ConanFile):
     name = "libhal-util"
-    version = "2.0.0"
+    version = "2.1.0"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/include/libhal-util/streams.hpp
+++ b/include/libhal-util/streams.hpp
@@ -29,31 +29,6 @@
 #include "timeout.hpp"
 
 namespace hal {
-/**
- * @brief Concept for a byte stream callable object
- *
- * @tparam T - object type
- */
-template<typename T>
-concept byte_stream = requires(T a) {
-                        a.state();
-                        {
-                          std::span<const hal::byte>() | a
-                          } -> std::same_as<std::span<const hal::byte>>;
-                      };
-
-/**
- * @brief Indicate if a byte stream object has finished its work
- *
- * @param p_byte_stream_object - the byte stream object to check
- * @return true - work state is either finished or failed
- * @return false - work state is still in progress
- */
-constexpr bool terminated(byte_stream auto p_byte_stream_object)
-{
-  return terminated(p_byte_stream_object.state());
-}
-
 namespace stream {
 /**
  * @brief Discard received bytes until the sequence is found

--- a/include/libhal-util/timeout.hpp
+++ b/include/libhal-util/timeout.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <functional>
 #include <ios>
 #include <system_error>
@@ -41,6 +42,48 @@ constexpr std::string_view to_string(work_state p_state)
 constexpr bool terminated(work_state p_state)
 {
   return p_state == work_state::finished || p_state == work_state::failed;
+}
+
+constexpr bool finished(work_state p_state)
+{
+  return p_state == work_state::finished;
+}
+
+constexpr bool in_progress(work_state p_state)
+{
+  return p_state == work_state::in_progress;
+}
+
+constexpr bool failed(work_state p_state)
+{
+  return p_state == work_state::failed;
+}
+
+template<typename T>
+concept has_work_state = requires(T a) {
+                           {
+                             a.state()
+                             } -> std::same_as<work_state>;
+                         };
+
+constexpr bool terminated(has_work_state auto p_worker)
+{
+  return terminated(p_worker.state());
+}
+
+constexpr bool finished(has_work_state auto p_worker)
+{
+  return finished(p_worker.state());
+}
+
+constexpr bool in_progress(has_work_state auto p_worker)
+{
+  return in_progress(p_worker.state());
+}
+
+constexpr bool failed(has_work_state auto p_worker)
+{
+  return failed(p_worker.state());
 }
 
 template<class CharT, class Traits>

--- a/tests/streams.test.cpp
+++ b/tests/streams.test.cpp
@@ -51,12 +51,6 @@ void stream_terminated_test()
   example_stream compiler_error_bypass_error;
   std::span<const hal::byte>() | compiler_error_bypass_error;
 
-  static_assert(hal::byte_stream<example_stream>);
-  static_assert(hal::byte_stream<hal::stream::parse<size_t>>);
-  static_assert(hal::byte_stream<hal::stream::find>);
-  static_assert(hal::byte_stream<hal::stream::fill_upto>);
-  static_assert(hal::byte_stream<hal::stream::skip>);
-
   "hal::terminate(byte_stream) -> true with finished state"_test = []() {
     // Setup
     example_stream stream;

--- a/tests/timeout.test.cpp
+++ b/tests/timeout.test.cpp
@@ -130,5 +130,69 @@ void timeout_test()
     // Verify
     expect(that % true == callback_error);
   };
+
+  "hal::work_state helper functions"_test = []() {
+    expect(that % false == hal::terminated(work_state::in_progress));
+    expect(that % true == hal::terminated(work_state::failed));
+    expect(that % true == hal::terminated(work_state::finished));
+
+    expect(that % true == hal::in_progress(work_state::in_progress));
+    expect(that % false == hal::in_progress(work_state::failed));
+    expect(that % false == hal::in_progress(work_state::finished));
+
+    expect(that % false == hal::finished(work_state::in_progress));
+    expect(that % false == hal::finished(work_state::failed));
+    expect(that % true == hal::finished(work_state::finished));
+
+    expect(that % false == hal::failed(work_state::in_progress));
+    expect(that % true == hal::failed(work_state::failed));
+    expect(that % false == hal::failed(work_state::finished));
+  };
+
+  "hal::work_state helper functions"_test = []() {
+    // Setup
+    struct always_in_progress
+    {
+      work_state state()
+      {
+        return work_state::in_progress;
+      }
+    };
+    struct always_failed
+    {
+      work_state state()
+      {
+        return work_state::failed;
+      }
+    };
+    struct always_finished
+    {
+      work_state state()
+      {
+        return work_state::finished;
+      }
+    };
+
+    always_in_progress always_in_progress_obj;
+    always_failed always_failed_obj;
+    always_finished always_finished_obj;
+
+    // Exercise + Verify
+    expect(that % false == hal::terminated(always_in_progress_obj));
+    expect(that % true == hal::terminated(always_failed_obj));
+    expect(that % true == hal::terminated(always_finished_obj));
+
+    expect(that % true == hal::in_progress(always_in_progress_obj));
+    expect(that % false == hal::in_progress(always_failed_obj));
+    expect(that % false == hal::in_progress(always_finished_obj));
+
+    expect(that % false == hal::finished(always_in_progress_obj));
+    expect(that % false == hal::finished(always_failed_obj));
+    expect(that % true == hal::finished(always_finished_obj));
+
+    expect(that % false == hal::failed(always_in_progress_obj));
+    expect(that % true == hal::failed(always_failed_obj));
+    expect(that % false == hal::failed(always_finished_obj));
+  };
 };
 }  // namespace hal


### PR DESCRIPTION
Helper functions to reduce code verbosity, when working with work_state values.